### PR TITLE
Fix the diffusers' "output_type=='np'" error.

### DIFF
--- a/ruyi/pipeline/pipeline_ruyi_inpaint.py
+++ b/ruyi/pipeline/pipeline_ruyi_inpaint.py
@@ -912,7 +912,8 @@ class RuyiInpaintPipeline(DiffusionPipeline):
         base_size = 512 // 8 // self.transformer.config.patch_size
         grid_crops_coords = get_resize_crop_region_for_grid((grid_height, grid_width), base_size)
         image_rotary_emb = get_2d_rotary_pos_embed(
-            self.transformer.inner_dim // self.transformer.num_heads, grid_crops_coords, (grid_height, grid_width)
+            self.transformer.inner_dim // self.transformer.num_heads, grid_crops_coords, (grid_height, grid_width),
+            output_type="pt"
         )
 
         style = torch.tensor([0], device=device)


### PR DESCRIPTION
Install Ruyi-Models in the latest ComfyUI_windows_portable (v0.3.4.1). After pressing the Run button, ComfyUI reports the following error:

```
# ComfyUI Error Report
## Error Details
- **Node ID:** 2
- **Node Type:** Ruyi_I2VSampler
- **Exception Type:** ValueError
- **Exception Message:** The deprecation tuple ("output_type=='np'", '0.33.0', "`get_2d_sincos_pos_embed` uses `torch` and supports `device`. `from_numpy` is no longer required.  Pass `output_type='pt' to use the new version now.") should be removed since diffusers' version 0.33.1 is >= 0.33.0
```

This because since version 0.33.0, diffusers deprecated the output_type='np' parameter in get_2d_sincos_pos_embed. 

Replaced it with output_type='pt'.

Thanks.
